### PR TITLE
bugfix: handled null values in arrays (fixes brentropy/only-nested#1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,12 @@ function only(whitelist, obj) {
   if (arguments.length === 1) {
     return only.bind(null, whitelist)
   }
+
+  // If the object is null, it must be a null value in an array. Just return it
+  if (obj === null) {
+    return obj;
+  }
+
   var ret = {}
   Object.keys(whitelist).forEach(function (key) {
     if (obj[key] !== void 0) {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,8 @@
 var should = require('should')
 var only = require('./index')
 
+console.log('TESTING');
+
 describe('The only() function', function () {
   
   var testDefault = {}
@@ -76,4 +78,11 @@ describe('The only() function', function () {
     result.should.have.property('a', null)
   })
 
+  it('should include null values in arrays', function() {
+    var whitelist = {a: [{x: null}]}
+    var obj = {a: [{x: 'something'}, null]}
+    var result = only(whitelist, obj)
+    result.a[0].should.have.property('x', 'something')
+    result.a[1].should.equal(null)
+  });
 })

--- a/test.js
+++ b/test.js
@@ -1,8 +1,6 @@
 var should = require('should')
 var only = require('./index')
 
-console.log('TESTING');
-
 describe('The only() function', function () {
   
   var testDefault = {}


### PR DESCRIPTION
I don't know why, but the tests wouldn't run for me. I tried a couple things but then gave up and just manually ran the code within the test in the node REPL.